### PR TITLE
Documentation fixes before public release

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -17,14 +17,17 @@
       title: HUGS with Docker
     - local: how-to/kubernetes
       title: HUGS with Kubernetes
-    - local: how-to/cloud/aws
-      title: HUGS on AWS
-    - local: how-to/cloud/gcp
-      title: (Soon) HUGS on Google Cloud
-    - local: how-to/cloud/azure
-      title: (Soon) HUGS on Azure
-    - local: how-to/cloud/digital-ocean
-      title: HUGS on DigitalOcean
+    - isExpanded: true
+      sections:
+        - local: how-to/cloud/aws
+          title: HUGS on AWS
+        - local: how-to/cloud/digital-ocean
+          title: HUGS on DigitalOcean
+        - local: how-to/cloud/gcp
+          title: (Soon) HUGS on Google Cloud
+        - local: how-to/cloud/azure
+          title: (Soon) HUGS on Azure
+      title: Cloud
   title: How to run HUGS
 - sections:
     - local: guides/inference

--- a/docs/source/faq.mdx
+++ b/docs/source/faq.mdx
@@ -21,8 +21,9 @@ You can deploy HUGS through various methods, including Docker and Kubernetes. Fo
 Yes, HUGS is available on major cloud platforms. For specific instructions, check our guides for:
 
 - [AWS](./how-to/cloud/aws.mdx)
-- [Google Cloud](./how-to/cloud/gcp.mdx)
-- [Azure](./how-to/cloud/azure.mdx) (coming soon)
+- [DigitalOcean](./how-to/cloud/digital-ocean.mdx)
+- [Google Cloud](./how-to/cloud/gcp.mdx) (coming soon)
+- [Microsoft Azure](./how-to/cloud/azure.mdx) (coming soon)
 
 ## How does HUGS pricing work?
 

--- a/docs/source/how-to/cloud/digital-ocean.mdx
+++ b/docs/source/how-to/cloud/digital-ocean.mdx
@@ -1,26 +1,26 @@
-# HUGS on Digital Ocean
+# HUGS on DigitalOcean
 
-The Hugging Face Generative AI Services, also known as HUGS, can be deployed in Digital Ocean (DO) via the GPU Droplets as 1-Click Models.
+The Hugging Face Generative AI Services, also known as HUGS, can be deployed in DigitalOcean (DO) via the GPU Droplets as 1-Click Models.
 
-This collaboration brings Hugging Face's extensive library of pre-trained models and their Text Generation Inference (TGI) solution to Digital Ocean customers, enabling seamless integration of state-of-the-art Large Language Models (LLMs) within the GPU Droplets of Digitial Ocean.
+This collaboration brings Hugging Face's extensive library of pre-trained models and their Text Generation Inference (TGI) solution to DigitalOcean customers, enabling seamless integration of state-of-the-art Large Language Models (LLMs) within the GPU Droplets of Digitial Ocean.
 
-HUGS provides access to a hand-picked and manually benchmarked collection of the most performant and latest open LLMs hosted in the Hugging Face Hub to TGI-optimized container applications, allowing users to deploy LLMs with a 1-Click deployment on Digital Ocean GPU Droplets.
+HUGS provides access to a hand-picked and manually benchmarked collection of the most performant and latest open LLMs hosted in the Hugging Face Hub to TGI-optimized container applications, allowing users to deploy LLMs with a 1-Click deployment on DigitalOcean GPU Droplets.
 
-With HUGS, developers can easily find, subscribe to, and deploy Hugging Face models using Digital Ocean's infrastructure, leveraging the power of NVIDIA GPUs on optimized, zero-configuration TGI containers.
+With HUGS, developers can easily find, subscribe to, and deploy Hugging Face models using DigitalOcean's infrastructure, leveraging the power of NVIDIA GPUs on optimized, zero-configuration TGI containers.
 
 ## 1-Click Deploy of HUGS in DO GPU Droplets
 
-1. Create a Digital Ocean account with a valid payment method, if you don't have one already, and make sure that you have enough quota to spin up GPU Droplets.
+1. Create a DigitalOcean account with a valid payment method, if you don't have one already, and make sure that you have enough quota to spin up GPU Droplets.
 
-2. Go to [Digital Ocean GPU Droplets](https://www.digitalocean.com/products/gpu-droplets) and create a new one.
+2. Go to [DigitalOcean GPU Droplets](https://www.digitalocean.com/products/gpu-droplets) and create a new one.
 
-![Create GPU Droplet on Digital Ocean](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/digital-ocean/create-gpu-droplet.png)
+![Create GPU Droplet on DigitalOcean](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/digital-ocean/create-gpu-droplet.png)
 
 3. Choose a data-center region (New York i.e. NYC2, or Toronto i.e. TOR1, available at the time of writing this).
 
 4. Choose the 1-Click Models when choosing an image, and select any of the available Hugging Face images that correspond to popular LLMs hosted on the Hugging Face Hub.
 
-![Choose 1-Click Models on Digital Ocean](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/digital-ocean/one-click-models.png)
+![Choose 1-Click Models on DigitalOcean](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/digital-ocean/one-click-models.png)
 
 5. Configure the remaining options, and click on "Create GPU Droplet" when done.
 
@@ -28,7 +28,7 @@ With HUGS, developers can easily find, subscribe to, and deploy Hugging Face mod
 
 Once the HUGS LLM has been deployed in a DO GPU Droplet, you can either connect to it via the public IP exposed by the instance, or just connect to it via the Web Console.
 
-![HUGS on Digital Ocean GPU Droplet](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/digital-ocean/hugs-gpu-droplet.png)
+![HUGS on DigitalOcean GPU Droplet](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/digital-ocean/hugs-gpu-droplet.png)
 
 When connected to the HUGS Droplet, the initial SSH message will display a Bearer Token, which is required to send requests to the public IP of the deployed HUGS Droplet.
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -38,9 +38,10 @@ To start using HUGS, you have several options. You can access HUGS as part of yo
 For detailed instructions on deployment and usage:
 
 - [Hugging Face Enterprise](https://huggingface.co/enterprise)
-- [Amazon Web Services (AWS)](./guides/aws.mdx)
-- [Google Cloud Platform (GCP)](./guides/gcp.mdx)
-- [DigitalOcean](./guides/digitalocean.mdx)
+- [Amazon Web Services (AWS)](./how-to/cloud/aws.mdx)
+- [DigitalOcean](./how-to/cloud/digital-ocean.mdx)
+- [Google Cloud Platform (GCP)](./how-to/cloud/gcp.mdx) (coming soon)
+- [Microsoft Azure](./how-to/cloud/azure.mdx) (coming soon)
 
 ## More Resources
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,5 +1,7 @@
 # Hugging Face Generative AI Services (HUGS)
 
+![HUGS Banner](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/hugs-banner.png)
+
 > Optimized, zero-configuration inference microservices for open AI models
 
 Hugging Face Generative AI Services (HUGS) are optimized, zero-configuration inference microservices designed to simplify and accelerate the development of AI applications with open models. Built on open-source Hugging Face technologies such as Text Generation Inference or Transformers. HUGS provides the best solution for efficiently building Generative AI Applications with open models and are optimized for a variety of hardware accelerators, including NVIDIA GPUs, AMD GPUs, AWS Inferentia (soon), and Google TPUs (soon).

--- a/docs/source/pricing.mdx
+++ b/docs/source/pricing.mdx
@@ -1,6 +1,6 @@
 # Pricing
 
-HUGS (Hugging Face Generative AI Services) offers a on-demand pricing based on the uptime of each container, except for Digital Ocean.
+HUGS (Hugging Face Generative AI Services) offers a on-demand pricing based on the uptime of each container, except for DigitalOcean.
 
 ## Cloud Marketplace Pricing
 
@@ -8,12 +8,13 @@ For deployments on major cloud platforms, HUGS is available through their respec
 
 - **AWS Marketplace**: $1 per hour per container
 - (Soon) **Google Cloud Platform (GCP) Marketplace**: $1 per hour per container
+- (Soon) **Microsoft Azure**
 
 This pricing model is based on the uptime of each container, allowing you to scale your usage according to your needs.
 
-## Digital Ocean
+## DigitalOcean
 
-HUGS is available on Digital Ocean free of charge. You only pay for the compute resources used to run the containers.
+HUGS is available on DigitalOcean free of charge. You only pay for the compute resources used to run the containers.
 
 ## Hugging Face Enterprise Customers
 


### PR DESCRIPTION
## Description

This PR fixes the following issues identified in hf.co/docs/hugs (already live):

- Missing banner within the `index` page
- "Digital Ocean" written with spacing instead of "DigitalOcean"
- Add missing "Cloud" subsection in the "How to run HUGS" section