### PR TITLE
Fix AWS mentions in the Google-Cloud-specific HUGS documentation

### DIFF
--- a/docs/source/how-to/cloud/gcp.mdx
+++ b/docs/source/how-to/cloud/gcp.mdx
@@ -4,11 +4,11 @@ The Hugging Face Generative AI Services, also known as HUGS, can be deployed in 
 
 This collaboration brings Hugging Face's extensive library of pre-trained models and their Text Generation Inference (TGI) solution to Google Cloud customers, enabling seamless integration of state-of-the-art Large Language Models (LLMs) within the Google Cloud infrastructure.
 
-HUGS provides access to a hand-picked and manually benchmarked collection of the most performant and latest open LLMs hosted in the Hugging Face Hub to TGI-optimized container applications, allowing users to deploy third-party Kubernetes applications on AWS or on-premises environments.
+HUGS provides access to a hand-picked and manually benchmarked collection of the most performant and latest open LLMs hosted in the Hugging Face Hub to TGI-optimized container applications, allowing users to deploy third-party Kubernetes applications on GCP or on-premises environments.
 
-With HUGS, developers can easily find, subscribe to, and deploy Hugging Face models using AWS infrastructure, leveraging the power of NVIDIA GPUs on optimized, zero-configuration TGI containers.
+With HUGS, developers can easily find, subscribe to, and deploy Hugging Face models using GCP infrastructure, leveraging the power of NVIDIA GPUs on optimized, zero-configuration TGI containers.
 
-## Subscribe to HUGS on AWS Marketplace
+## Subscribe to HUGS on GCP Marketplace
 
 1. Go to [HUGS Google Cloud Marketplace listing](https://console.cloud.google.com/marketplace/product/huggingface-public/hugs)
 


### PR DESCRIPTION
There appear to be some copy-paste residuals or typos in the HUGS-on-GCP documentation - submitting a PR for a very simple/minimal fix. The rest of the doc looks great.